### PR TITLE
Miscelanous RFC

### DIFF
--- a/src/bup.rs
+++ b/src/bup.rs
@@ -43,7 +43,6 @@ impl Default for Bup {
 impl RollingHash for Bup {
     type Digest = u32;
 
-    #[inline(always)]
     fn roll_byte(&mut self, newch: u8) {
         // Since this crate is performance ciritical, and
         // we're in strict control of `wofs`, it is justified
@@ -55,12 +54,10 @@ impl RollingHash for Bup {
         self.wofs = (self.wofs + 1) % WINDOW_SIZE;
     }
 
-    #[inline(always)]
     fn digest(&self) -> u32 {
         ((self.s1 as u32) << 16) | ((self.s2 as u32) & 0xffff)
     }
 
-    #[inline]
     fn reset(&mut self) {
         *self = Bup {
             chunk_bits: self.chunk_bits,
@@ -103,7 +100,6 @@ impl Bup {
         }
     }
 
-    #[inline(always)]
     fn add(&mut self, drop: u8, add: u8) {
         self.s1 += add as usize;
         self.s1 -= drop as usize;

--- a/src/gear.rs
+++ b/src/gear.rs
@@ -76,14 +76,17 @@ impl CDC for Gear {
             );
         let mask = !0u64 << (DIGEST_SIZE as u32 - self.chunk_bits);
 
-        for (i, &b) in buf.iter().enumerate() {
-            self.roll_byte(b);
+        let mut digest = self.digest;
 
-            if self.digest() & mask == 0 {
+        for (i, &b) in buf.iter().enumerate() {
+            digest = (digest << 1).wrapping_add(unsafe { *G.get_unchecked(b as usize) });
+
+            if digest & mask == 0 {
                 self.reset();
                 return Some((&buf[..i+1], &buf[i+1..]));
             }
         }
+        self.digest = digest;
         None
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,21 +18,17 @@ pub use gear::Gear;
 pub trait RollingHash {
     type Digest;
 
-    #[inline(always)]
     fn roll_byte(&mut self, buf: u8);
 
     /// Roll over a slice of bytes
-    #[inline(always)]
     fn roll(&mut self, buf: &[u8]) {
         buf.iter().map(|&b| self.roll_byte(b)).count();
     }
 
     /// Return current rolling sum digest
-    #[inline(always)]
     fn digest(&self) -> Self::Digest;
 
     /// Resets the internal state
-    #[inline(always)]
     fn reset(&mut self);
 }
 
@@ -48,7 +44,6 @@ trait CDC {
     /// * Some - chunk edge was found, and it is splitting the `buf`
     ///          in two pieces. The second one has not yet been searched
     ///          for more chunks.
-    #[inline]
     fn find_chunk<'a>(&mut self, buf: &'a [u8]) -> Option<(&'a [u8], &'a [u8])>;
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use super::Engine;
+use super::RollingHash;
 use rand::{Rng, SeedableRng, StdRng};
 
 #[test]
@@ -34,4 +34,16 @@ fn bup_selftest()
     assert_eq!(sum1a, sum1b);
     assert_eq!(sum2a, sum2b);
     assert_eq!(sum3a, sum3b);
+}
+
+pub fn test_data_1mb() -> Vec<u8> {
+    let mut v = vec![0x0; 1024 * 1024];
+
+    let seed: &[_] = &[2, 1, 255, 70];
+    let mut rng: StdRng = SeedableRng::from_seed(seed);
+    for i in 0..v.len() {
+        v[i] = rng.gen();
+    }
+
+    v
 }


### PR DESCRIPTION
I was toying a bit, trying to find a way to remove a performance hit found in #11 , and also with the API. 

I really like the

```
fn find_chunk<'a>(&mut self, buf: &'a [u8]) -> Option<(&'a [u8], &'a [u8])>;
```

API. It gives a nice, idiomatic, low-level handling loop:

```
    let mut buf = v.as_slice();
    while let Some((last, rest)) = cdc.find_chunk(buf) {
        // handle `last` piece of the chunk
        buf = rest;
    }
    // handle leftover `buf` here 
```

and should be easy to build iterators,  `Read/Write` adapters, and other APIs on top of it.

I'm not sure if this should get merged as a whole, but if you can let me know what seems OK, and what not, I could prepare more targeted patches.