### PR TITLE
Fix the default edge detection for Gear

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ mod tests {
     use nanorand::{Rng, WyRand};
     use std::collections::HashSet;
 
-    fn rand_data(len: usize) -> Vec<u8> {
+    pub(crate) fn rand_data(len: usize) -> Vec<u8> {
         let mut data = vec![0; len];
         let mut rng = WyRand::new_seed(0x01020304);
         rng.fill_bytes(&mut data);


### PR DESCRIPTION
Missed a conversion from bytes to bits, which made the default edge
detection fail. Addiontally, add test code to actually call the default
edge detection functions for both Bup and Gear